### PR TITLE
Tweak install directions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ An easy way to install both OCaml and the necessary libraries is to install [opa
   NOTE: HZ requires TyXML 4.0, which is NOT backwards compatible with TyXML 3.X.
 
     ```sh
-    > opam install js_of_ocaml tyxml deriving ppx_deriving reactiveData ocp-indent
+    > opam install js_of_ocaml tyxml js_of_ocaml-tyxml deriving ppx_deriving reactiveData ocp-indent
     ```
 
   - To make sure you have the latest versions of everything, ask `opam` to upgrade the packages if needed:
@@ -71,7 +71,7 @@ You can execute build.sh to compile hz.ml.
 
 ```sh
 > cd src/
-> /bin/sh build.sh
+> ./build.sh
 ```
 
 It consists of two steps:

--- a/src/build.sh
+++ b/src/build.sh
@@ -1,3 +1,5 @@
+#!/bin/sh
+
 for f in `find . -name '*.ml'` ; \
 do ( \
 ocp-indent -i $f; \


### PR DESCRIPTION
1. I needed to also install the `js_of_ocaml-tyxml` package.
2. `build.sh` is marked executable but was missing an interpreter
   directive.